### PR TITLE
Crack Shot updates along with start of Snap Shot work

### DIFF
--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -5249,7 +5249,7 @@ var UPGRADES=window.UPGRADES= [
                  sh.hasfired = 0;
              }
          });
-	 Unit.prototype.wrap_before("doendmaneuveraction",self,function() {
+	 Unit.prototype.wrap_before("endmaneuver",self,function() {
              // There are some restrictions on Snap Shot that should be checked prior
              // to adding any functionality to the holder (self.unit):
              // 1) activeunit is not self.unit                          check
@@ -5262,7 +5262,7 @@ var UPGRADES=window.UPGRADES= [
             {
                 if(self.phase < phase){
                    sh.doselection(function(n) {
-                       self.unit.select();
+                       //self.unit.select();
                        self.unit.wrap_before("selecttargetforattack",self,function() {
                            self.unit.endnoaction(n,"ATTACK");
                        }).unwrapper("cleanupattack");

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -5218,7 +5218,6 @@ var UPGRADES=window.UPGRADES= [
      isWeapon: function() { return true;},
      isTurret: function() { return false;},
      // Snap Shot can only fire once per *phase*
-     // Not sure how to enact that part, though.
      endattack: function(c,h) {
         this.lastphase = this.phase;
         this.phase = phase;
@@ -5262,7 +5261,7 @@ var UPGRADES=window.UPGRADES= [
             {
                 if(self.phase < phase){
                    sh.doselection(function(n) {
-                       //self.unit.select();
+                       self.unit.select();
                        self.unit.wrap_before("selecttargetforattack",self,function() {
                            self.unit.endnoaction(n,"ATTACK");
                        }).unwrapper("cleanupattack");
@@ -5292,7 +5291,7 @@ var UPGRADES=window.UPGRADES= [
                        // In this context, self.unit is Snap Shot host
                        // this is any ship
                         self.unit.doattack([self.unit.weapons[self.index]],[this]);
-                   }.bind(this));
+                   }.bind(this), this);
                 }
             }
 	 });

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -5223,6 +5223,7 @@ var UPGRADES=window.UPGRADES= [
         this.lastphase = this.phase;
         this.phase = phase;
      },
+     firesnd:"",
      attack: 2,
      range: [1,1],
      lastphase: -1,
@@ -5231,14 +5232,24 @@ var UPGRADES=window.UPGRADES= [
      index: -1,
      init: function(sh) {
 	 var self=this;
+         self.firesnd=self.unit.ship.firesnd;
          for (var i in self.unit.weapons){
              if (self.unit.weapons[i] == self){
                  this.index = i;
                  break;
              }
          }
-         
-	 Unit.prototype.wrap_after("doendmaneuveraction",self,function() {
+         sh.wrap_after("resolveattack", self, function(){
+             if(phase != COMBAT_PHASE){
+                 sh.hasfired = 0;
+             }
+         });
+         sh.wrap_after("cancelattack", self, function(){
+             if(phase != COMBAT_PHASE){
+                 sh.hasfired = 0;
+             }
+         });
+	 Unit.prototype.wrap_before("doendmaneuveraction",self,function() {
              // There are some restrictions on Snap Shot that should be checked prior
              // to adding any functionality to the holder (self.unit):
              // 1) activeunit is not self.unit                          check

--- a/src/xwings.js
+++ b/src/xwings.js
@@ -558,7 +558,7 @@ function displaycompareresults(u,f) {
     var adm=u.getresultmodifiers(targetunit.dr,targetunit.dd,Unit.DEFENDCOMPARE_M,Unit.DEFENSE_M);
     var ddm=targetunit.getresultmodifiers(targetunit.dr,targetunit.dd,Unit.DEFENDCOMPARE_M,Unit.DEFENSE_M);
 
-    if (FAST||(dam.length==0&&aam.length==0&&adm.length==0&&ddm.length==0)) {
+    if (FAST||u.ia||(dam.length==0&&aam.length==0&&adm.length==0&&ddm.length==0)) {
 	$("#combatdial").hide();
 	//log("hiding combat dial compare");
 	f();
@@ -567,7 +567,8 @@ function displaycompareresults(u,f) {
 	$("#dtokens").append($("<button>").addClass("m-fire").click(function() {
 	    $("#combatdial").hide();
 	    //log("hiding combat dial finally");
-	    f();}.bind(u)));
+	    f();
+        }.bind(u)));
     }
 }
 


### PR DESCRIPTION
While working on Snap Shot *with* Crack Shot (one of the more troublesome combos) I found some edge cases that needed fixing up.  Also, I hate Snap Shot with every fibre of my being.  Currently Snap Shot is usable on single human ships, but cannot be reliably used with more than one at a time.  I haven't even really tested IAUnit compatibility.

Here's the Crack Shot rundown:
1) Crack Shot should be considered an "Add dice" mod rather than a direct dice result mod, in order for it to be usable with Snap Shot and because it is cancelling a die rather than changing its result.  Unfortunately this required reformatting the return value as a dictionary, since the IAUnit[2] handler for Unit.ADD_M requires that format.

2) While useful, the addition of extra dice modification check steps after comparison means there are now new opportunities to mistakenly display UI elements when AI units are trying to use dice modifiers.  I added an "is the current active ship an IAunit" check to prevent e.g. Crack Shot icon from displaying when it's being used by an AI ship against a human.

3) Added an extra check to Crack Shot to make sure the AI ship wasn't trying to use Crack Shot against itself (basically allowing earlier escape to cut down calculations).  Again, this is necessary because IAUnit[2] handles mods differently from base Units; without this check an IAUnit may use its own Crack Shot on itself when it is the target of an enemy attack.