### PR TITLE
Fix for Kylo Ren (TIE Silencer) list import issue, and normalized files

### DIFF
--- a/data/strings.en.json
+++ b/data/strings.en.json
@@ -267,7 +267,7 @@
 	"Lieutenant Karsabi":{"text":"When you receive a weapons disabled token, if you are not stressed, you may receive 1 stress token to remove it."},
 	"Torani Kulda":{"text":"After you perform an attack, each enemy ship inside your bullseye firing arc at Range 1-3 must choose to suffer 1 damage or remove all of its focus and evade tokens."},
 	"Dalan Oberos (Kimogila)":{"text":"At the start of the Combat phase, you may acquire a target lock on an enemy ship inside your bullseye firing arc at Range 1-3."},
-	"Fenn Rau (Rebel)":{"text":"When an enemy ship inside your firing arc at Range 1-3 becomes the active ship during the Combat Phase, if you are not stressed you may receive one stress token. If you do, that ship cannot spend tokens to modify its dice when attacking this round."},
+	"Fenn Rau":{"text":"When an enemy ship inside your firing arc at Range 1-3 becomes the active ship during the Combat Phase, if you are not stressed you may receive one stress token. If you do, that ship cannot spend tokens to modify its dice when attacking this round."},
 	"AP-5":{"text":"When you perform the coordinate action, after you choose a friendly ship and before it performs a free action, you may receive 2 stress tokens to remove 1 stress token from it."},
 	"Kylo Ren (TIE Silencer)":{"text":"The first time you are hit by an attack each round, assign the 'I'll Show You the Dark Side' Condition card to the attacker."},
 	"Test Pilot 'Blackout'":{"text":"When attacking, if the attack is obstructed, the defender rolls 2 fewer defense dice (to a minimum of 0)."},

--- a/data/xws.json
+++ b/data/xws.json
@@ -341,7 +341,7 @@
     "dalanoberoskimogila":"Dalan Oberos (Kimogila)",
     "toranikulda":"Torani Kulda",
     "m12lkimogilafighter":"M12-L Kimogila Fighter",
-    "nusquadronveteran":"Nu Squadron Veteran",
+    "nusquadronpilot":"Nu Squadron Pilot",
     "rhosquadronveteran":"Rho Squadron Veteran",
     "lieutenantkarsabi":"Lieutenant Karsabi",
     "majorvynder":"Major Vynder",

--- a/data/xws.json
+++ b/data/xws.json
@@ -331,7 +331,6 @@
     "sienarjaemusanalyst":"Sienar-Jaemus Analyst",
     "firstordertestpilot":"First Order Test Pilot",
     "testpilotblackout":"Test Pilot 'Blackout'",
-    "kylorentiesilencer":"Kylo Ren (TIE Silencer)",
     "tiesilencer":"TIE Silencer",
     "ap5":"AP-5",
     "zeborrelios":"'Zeb' Orrelios",

--- a/data/xws.json
+++ b/data/xws.json
@@ -568,7 +568,7 @@
     "tiepunisher":"TIE Punisher",
     "redline":"'Redline'",
     "deathrain":"'Deathrain'",
-    "blackeightsquadronpilot":"Black Eight Squadron Pilot",
+    "blackeightsqpilot":"Black Eight Squadron Pilot",
     "cutlasssquadronpilot":"Cutlass Squadron Pilot",
     "gozanticlasscruiser":"Gozanti-class Cruiser",
     "tieadvancedprototype":"TIE Advanced Prototype",

--- a/data/xws.json
+++ b/data/xws.json
@@ -335,7 +335,6 @@
     "ap5":"AP-5",
     "zeborrelios":"'Zeb' Orrelios",
     "ezrabridger":"Ezra Bridger",
-    "fennrau":"Fenn Rau (Rebel)",
     "sheathipedeclassshuttle":"Sheathipede-class Shuttle",
     "cartelbrute":"Cartel Brute",
     "cartelexecutioner":"Cartel Executioner",

--- a/src/pilots.js
+++ b/src/pilots.js
@@ -5213,6 +5213,8 @@ window.PILOTS = [
 		pilotid:273,
 		unique:true,
 		unit:"TIE Silencer",
+                edition:"TIE Silencer",
+                ambiguous:true,
 		skill:9,
 		done:true,
 		upgrades:[Unit.ELITE,Unit.SYSTEM,Unit.TECH],

--- a/src/pilots.js
+++ b/src/pilots.js
@@ -5208,7 +5208,7 @@ window.PILOTS = [
 		upgrades:[Unit.CREW,Unit.ASTROMECH]
 	},
 	{
-		name:"Kylo Ren (TIE Silencer)",
+		name:"Kylo Ren",
 		faction:Unit.EMPIRE,
 		pilotid:273,
 		unique:true,

--- a/src/pilots.js
+++ b/src/pilots.js
@@ -5158,11 +5158,13 @@ window.PILOTS = [
 	       upgrades:[Unit.TORPEDO,Unit.MISSILE,Unit.SALVAGED,Unit.ILLICIT]
 	},
 	{
-		name:"Fenn Rau (Rebel)",
+		name:"Fenn Rau",
 		faction:Unit.REBEL,
 		unique:true,
     	    	unit:"Sheathipede-class Shuttle",
     	    	skill:9,
+                edition:"Sheathipede",
+                ambiguous:true,
 		pilotid:269,
 		points:20,
 		done:false,

--- a/src/pilots.js
+++ b/src/pilots.js
@@ -5104,7 +5104,7 @@ window.PILOTS = [
 	        upgrades: [Unit.ELITE,Unit.TORPEDO,Unit.MISSILE]
 	},
 	{
-        	name: "Nu Squadron Veteran",
+        	name: "Nu Squadron Pilot",
 	        faction:Unit.EMPIRE,
 		done:true,
 		pilotid:264,

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -3974,12 +3974,16 @@ var UPGRADES=window.UPGRADES= [
 	init: function(sh) {
 	    var phantom=-1;
 	    var self=this;
+            var upg;
 	    for (var i in squadron) {
 		var u=squadron[i];
 		if (u.isally(sh)&&sh!=u) {
 		    for (var j=0; j<u.upgrades.length; j++) {
-			var upg=u.upgrades[j];
-			if (upg.name=="Phantom") { phantom=i; break; }
+			upg=u.upgrades[j];
+			if (upg.name=="Phantom" || upg.name=="Phantom II") { 
+                            phantom=i; 
+                            break; 
+                        }
 		    }
 		}
 		if (phantom!=-1) break;
@@ -4003,20 +4007,28 @@ var UPGRADES=window.UPGRADES= [
 			}.bind(this)}],"",true);
 		    }
 		});
-		
-		sh.wrap_after("endcombatphase",this,function() {
-		    if (this.docked) 
-			for (var i=0; i<this.weapons.length; i++) {
-			    var u=this.weapons[i];
-			    if (u.type==Unit.TURRET&&u.isactive&&this.noattack<round) {
-				this.log("+1 attack with %1 [%0]",self.name,u.name);
-				// added attack
-				this.noattack=round;
-				this.selecttargetforattack(i);
-				break;
-			    }
-			}	
-		});
+		if(upg.name=="Phantom"){
+                    sh.wrap_after("endcombatphase",this,function() {
+                        if (this.docked) 
+                            for (var i=0; i<this.weapons.length; i++) {
+                                var u=this.weapons[i];
+                                if (u.type==Unit.TURRET&&u.isactive&&this.noattack<round) {
+                                    this.log("+1 attack with %1 [%0]",self.name,u.name);
+                                    // added attack
+                                    this.noattack=round;
+                                    this.selecttargetforattack(i);
+                                    break;
+                                }
+                            }	
+                    });
+                }
+                else { // experimental Ghost + Phantom II
+                    sh.wrap_after("endactivationphase",this,function() {
+                        if(this.docked && this.candocoordinate()){
+                            this.doaction([this.newaction(this.resolvecoordinate, "COORDINATE")],"Select unit to Coordinate");
+                        }
+                    }.bind(sh));
+                }
 		sh.wrap_after("dies",this,function() {
 		    if (this.docked) {
 			this.docked.noattack=round;
@@ -4039,6 +4051,13 @@ var UPGRADES=window.UPGRADES= [
      unique:true,
      done:true,
      ship:"Attack Shuttle"
+    },
+    {name:"Phantom II",
+     type:Unit.TITLE,
+     points:0,
+     unique:true,
+     done:false,
+     ship:"Sheathipede-class Shuttle"
     },
     {name:"Reinforced Deflectors",
      points:3,


### PR DESCRIPTION
While working on the auto-pushed tournament file project, I noticed that the TIE Silencer version of Kylo Ren was not being imported correctly, leading to an exception.

The issue boiled down to this: List Juggler uses "name" + "ship" key pairs to uniquely identify pilot+ship cards where the pilot may fly more than one ship.  XWS-Bench uses those keys when importing List Juggler information, but uses the internal "edition" and "ambiguous" keys to signal to itself that it is generating a list with such a pilot.

Adding "ambiguous: true" and "edition: "TIE Silencer"" to pilot.js, and making sure that both xws.json and pilots.js contain only entries named "Kylo Ren" fixed the import issues and, more importantly, puts Kylo Ren in line with other multi-ship pilots like Han Solo, Maarek Stele, Sabina Wren, etc.

I've verified that the below fixes A) allow for properly importing List Juggler data containing "name": "kyloren", "ship": "tiesilencer" data, B) properly save Kylo Ren Tie Silencer instances in the Saved Squads tab, and C) allow for later editing Kylo Ren-containing lists (previously the Upsilon-class Shuttle version would be displayed instead).