### PR TITLE
Linked Battery / Unguided Rockets / Omega Leader fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ howto.txt~
 *~
 *.sh~
 *.py~
+.DS_Store

--- a/data/strings.en.json
+++ b/data/strings.en.json
@@ -758,8 +758,8 @@
 	"Wookiee Commandos":{"text":"When attacking, you may reroll your focus results."},
 	"Xg-1 Assault Configuration":{"text":"ALPHA-CLASS STAR WING ONLY. TITLE. Your upgrade bar gains two Cannons upgrade icons. You may perform attacks with cannons secondary weapons that cost two or fewer squad points even while you have a weapons disabled token."},
 	"Os-1 Arsenal Loadout":{"text":"ALPHA-CLASS STAR WING ONLY. TITLE. Your upgrade bar gains the Torpedo and Missile upgrade icons. You may perform attacks with torpedo and missile secondary weapons against ships you have locked even while you have a weapons disabled token."},
-	"Vaksai":{"text":"KIHRAXZ FIGHTER ONLY. TITLE. The squad point cost of each of your equipped upgrades is reduced by 1 (to a minimum of 0). You may equip up to 3 different modification upgrades."}
-
+    "Vaksai":{"text":"KIHRAXZ FIGHTER ONLY. TITLE. The squad point cost of each of your equipped upgrades is reduced by 1 (to a minimum of 0). You may equip up to 3 different modification upgrades."},
+    "Linked Battery":{"text":"When attacking with a primary weapon or a %CANNON% secondary weapon, you may reroll 1 attack die."}
 },
     "criticals":{
 	"Weapons Failure":{"text":"When attacking, roll 1 fewer attack die. %ACTION% Roll 1 attack die. On a %HIT% or %CRIT% result, flip this card facedown."},

--- a/data/strings.en.json
+++ b/data/strings.en.json
@@ -759,7 +759,8 @@
 	"Xg-1 Assault Configuration":{"text":"ALPHA-CLASS STAR WING ONLY. TITLE. Your upgrade bar gains two Cannons upgrade icons. You may perform attacks with cannons secondary weapons that cost two or fewer squad points even while you have a weapons disabled token."},
 	"Os-1 Arsenal Loadout":{"text":"ALPHA-CLASS STAR WING ONLY. TITLE. Your upgrade bar gains the Torpedo and Missile upgrade icons. You may perform attacks with torpedo and missile secondary weapons against ships you have locked even while you have a weapons disabled token."},
     "Vaksai":{"text":"KIHRAXZ FIGHTER ONLY. TITLE. The squad point cost of each of your equipped upgrades is reduced by 1 (to a minimum of 0). You may equip up to 3 different modification upgrades."},
-    "Linked Battery":{"text":"When attacking with a primary weapon or a %CANNON% secondary weapon, you may reroll 1 attack die."}
+    "Linked Battery":{"text":"When attacking with a primary weapon or a %CANNON% secondary weapon, you may reroll 1 attack die."},
+    "Unguided Rockets":{"text":"<strong>Attack (Focus):</strong> Attack 1 ship. Your attack dice can be modified only by spending a focus token for its standard effect."}
 },
     "criticals":{
 	"Weapons Failure":{"text":"When attacking, roll 1 fewer attack die. %ACTION% Roll 1 attack die. On a %HIT% or %CRIT% result, flip this card facedown."},

--- a/data/xws.json
+++ b/data/xws.json
@@ -327,7 +327,8 @@
     "xg1assaultconfiguration": "Xg-1 Assault Configuration",
     "os1arsenalloadout": "Os-1 Arsenal Loadout",
     "vaksai": "Vaksai",
-    "linkedbattery": "Linked Battery"
+    "linkedbattery": "Linked Battery",
+    "unguidedrockets": "Unguided Rockets"
 },
 "pilots":{
     "crimsonsquadronpilot":"Crimson Squadron Pilot",

--- a/data/xws.json
+++ b/data/xws.json
@@ -326,7 +326,8 @@
     "wookieecommandos": "Wookiee Commandos",
     "xg1assaultconfiguration": "Xg-1 Assault Configuration",
     "os1arsenalloadout": "Os-1 Arsenal Loadout",
-    "vaksai": "Vaksai"
+    "vaksai": "Vaksai",
+    "linkedbattery": "Linked Battery"
 },
 "pilots":{
     "crimsonsquadronpilot":"Crimson Squadron Pilot",

--- a/src/pilots.js
+++ b/src/pilots.js
@@ -3192,7 +3192,7 @@ window.PILOTS = [
 			var p=[];
 			for (var i=0; i<mods.length; i++)
 			    if (mods[i].from!=Unit.ATTACK_M) p.push(mods[i]);
-			return mods;
+			return p;
 		    }).unwrapper("endattack");
 	    });
 	    this.wrap_before("resolveattack",this,function(w,t) {
@@ -3201,8 +3201,7 @@ window.PILOTS = [
 			var p=[];
 			for (var i=0; i<mods.length; i++)
 			    if (mods[i].from!=Unit.DEFENSE_M) p.push(mods[i]);
-			
-			return mods;
+			return p;
 		    }).unwrapper("endbeingattacked");
 	    });
 	   this.wrap_after("setpriority",this,function(a) {

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -6543,5 +6543,28 @@ var UPGRADES=window.UPGRADES= [
 				}.bind(this)
 			});
 		}
+	},
+    {
+		name: "Unguided Rockets",
+		type:Unit.MISSILE,
+		done:true,
+		points:2,
+		attack:3,
+		range:[1,3],
+		firesnd:"missile",
+		requires:"Focus",
+		consumes:false,
+		init: function(sh) {
+			var self = this;
+			sh.wrap_before("resolveattack",this,function(w,t) {
+			if(this.weapons[this.activeweapon]==self)
+				this.wrap_after("getdicemodifiers",this,function(mods) {
+				var p=[];
+				for (var i=0; i<mods.length; i++)
+					if (mods[i].from==Unit.ATTACK_M && mods[i].str=="focus" && mods[i].token==true) p.push(mods[i]);
+				return p;
+				}).unwrapper("cleanupattack");
+			});
+		}
 	}
 ];

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -6554,6 +6554,7 @@ var UPGRADES=window.UPGRADES= [
 		firesnd:"missile",
 		requires:"Focus",
 		consumes:false,
+		takesdouble: true,
 		init: function(sh) {
 			var self = this;
 			sh.wrap_before("resolveattack",this,function(w,t) {

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -6566,6 +6566,9 @@ var UPGRADES=window.UPGRADES= [
 				return p;
 				}).unwrapper("cleanupattack");
 			});
+		},
+		desactivate: function() {
+			return false;
 		}
 	}
 ];

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -6525,4 +6525,23 @@ var UPGRADES=window.UPGRADES= [
 			}
 		}
 	},
+	{
+		name: "Linked Battery",
+		type:Unit.CANNON,
+		done:true,
+		points:2,
+		limited:true,
+		isLarge:false,
+		isWeapon: function() { return false; },
+		init: function(sh) {
+			sh.adddicemodifier(Unit.ATTACK_M,Unit.REROLL_M,Unit.ATTACK_M,this,{
+				dice:["blank","focus"],
+				n:function() { return 1; },
+				req:function(a,w,defender) {
+					var w1=a.weapons[a.activeweapon];
+					return this.isactive && (w1.isprimary || w1.type==Unit.CANNON);
+				}.bind(this)
+			});
+		}
+	}
 ];


### PR DESCRIPTION
Added new cards Linked Battery and Unguided Rockets.
Fixed a bug where Omega Leader was not preventing dice mods (returning original list of mods instead of newly calculated).