### PR TITLE
Snap Shot fully working

### DIFF
--- a/src/units.js
+++ b/src/units.js
@@ -2356,6 +2356,11 @@ Unit.prototype = {
 	actionr[n].resolve(type);
 	//this.log("n="+n+" "+(actionr.length-1));
 	if (n==actionr.length-1) {
+            if(actionrlock.state()=="resolved"){
+                actionrlock.done(function() { // Attempt to handle resolve inversion
+                    this.unlock(); 
+                    if(phase==ACTIVATION_PHASE) this.endactivate(); }.bind(this));
+                }
 	    actionrlock.resolve();
 	}
 	this.show();

--- a/src/units.js
+++ b/src/units.js
@@ -3039,7 +3039,9 @@ Unit.prototype = {
     actionbarrier:function() {
 	actionrlock=$.Deferred();
 	if (this.areactionspending()) {
-	    actionrlock.done(function() { this.unlock(); if(phase==ACTIVATION_PHASE) this.endactivate(); }.bind(this));
+	    actionrlock.done(function() { 
+                this.unlock(); 
+                if(phase==ACTIVATION_PHASE) this.endactivate(); }.bind(this));
 	} else {
 	    actionrlock.resolve();
 	    if(phase!==ACTIVATION_PHASE||this.hasmoved){

--- a/src/units.js
+++ b/src/units.js
@@ -2936,7 +2936,9 @@ Unit.prototype = {
 	    for (i=0; i<list.length; i++) {
 		(function(k,h) {
 		    var e=$("<div title='"+k.name+"'>").addClass("symbols").text(A[k.type].key)
-			.click(function () { this.resolvenoaction(k,n) }.bind(this));
+			.click(function () { 
+                            this.resolvenoaction(k,n) 
+                }.bind(this));
 		    $("#actiondial > div").append(e);
 		}.bind(this))(list[i],i);
 	    }

--- a/src/units.js
+++ b/src/units.js
@@ -3493,7 +3493,7 @@ Unit.prototype = {
 	this.showpanel();
 	this.showdial();
 	this.showmaneuver();
-	if (phase==ACTIVATION_PHASE) this.showactivation();
+	if (phase==ACTIVATION_PHASE&&!this.hasfired) this.showactivation();
 	if (!ENGAGED&&phase==COMBAT_PHASE){
 	    if (this.canfire()&&!this.areactionspending()&&!INREPLAY) this.showattack(this.activeweapons,this.activeenemies); 
 	    else $("#attackdial").empty();

--- a/src/units.js
+++ b/src/units.js
@@ -2760,6 +2760,7 @@ Unit.prototype = {
     },
     endmaneuver: function() {
 	var p=this.ionized;
+        var notThisTeam=(this.team===1?2:1);
 	if (this.hasionizationeffect()) 
 	    for (var i=0; i<p; i++) this.removeiontoken();
 	this.maneuver=-1;
@@ -2767,7 +2768,18 @@ Unit.prototype = {
 	this.show();
 	this.moves=[];
 	if (this.checkdead()) { this.hull=0; this.shield=0; } 
-	else this.doendmaneuveraction();
+        else { 
+            // First-pass event handler triggering for endmaneuver stuff
+            if(TEAMS[this.team].initiative){ // Possibly unnecessary init order
+                $(document).trigger("endmaneuver"+this.team, [this]);
+                $(document).trigger("endmaneuver"+notThisTeam, [this]);
+            }
+            else{ // Trigger order matters for e.g. Kanan v. Snap Shot
+                $(document).trigger("endmaneuver"+notThisTeam, [this]);
+                $(document).trigger("endmaneuver"+this.team, [this]);
+            }
+            this.doendmaneuveraction();
+        }
 	//this.log("endmaneuver");
 	this.cleanupmaneuver();
     },

--- a/src/units.js
+++ b/src/units.js
@@ -3042,8 +3042,10 @@ Unit.prototype = {
 	    actionrlock.done(function() { this.unlock(); if(phase==ACTIVATION_PHASE) this.endactivate(); }.bind(this));
 	} else {
 	    actionrlock.resolve();
-	    this.unlock();
+	    if(phase!==ACTIVATION_PHASE||this.hasmoved){
+                this.unlock();
 		if(phase==ACTIVATION_PHASE) this.endactivate();
+            }
 	}
     },
     addafteractions: function(f) {

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -5437,109 +5437,81 @@ var UPGRADES=window.UPGRADES= [
      init: function(sh) {
         var self=this;
         self.firesnd=self.unit.ship.firesnd;
+        var notThisTeam=(sh.team===1)?2:1;
+        //var onElement=(sh.team===1)?"#player1":"player2"; // May use if document gets too crowded
         for (var i in self.unit.weapons){
             if (self.unit.weapons[i] == self){
                 this.index = i;
                 break;
             }
         }
-        sh.wrap_after("resolveattack", self, function(){
-            if(phase != COMBAT_PHASE){
-                sh.hasfired = 0;
-            }
-        });
-        sh.wrap_after("cancelattack", self, function(){
-            if(phase != COMBAT_PHASE){
-                sh.hasfired = 0;
-            }
-        });
         sh.wrap_after("endcombatphase", self, function(){
             self.lastphase=self.phase;
             self.phase=-1;
-        })
-        var notThisTeam=(sh.team===1)?2:1;
+        });        
         $(document).on("endmaneuver"+notThisTeam, function(e,ship){
-            if(!ship.isally(sh))
-                if(self.getenemiesinrange([ship]).length>0)
+            if(!ship.isally(sh)&&!sh.dead){ // Dead ships still have handlers
+                if(self.getenemiesinrange([ship]).length>0){
                     if(self.phase < phase){
-                        sh.wrap_after("getdicemodifiers",self,function() {
-                            // Iterate back through arguments (all mods available to self.unit
-                            // and remove any that Mod or Reroll the Attack Dice 
-                             var i = arguments[0].length;
-                             var newargs = arguments[0].slice();
-                             var nextarg;
-                             while (i--) {
-                                 nextarg = newargs[i];
-                                 if(nextarg.to == Unit.ATTACK_M || nextarg.from == Unit.ATTACK_M){
-                                     if (newargs[i].type==Unit.MOD_M || newargs[i].type==Unit.REROLL_M) { 
-                                         newargs.splice(i, 1);
-                                     } 
-                                 }
-                             }
-                             return newargs;
-                        }).unwrapper("cleanupattack");
-                        ship.log("Bang Bang! %0 attack from %1 against %2", self.name, sh.name, ship.name);
-                        //self.unit.selecttargetforattack(self.index,[ship]);
-                        $("#attackdial").empty();
-                        ENGAGED=true;
-                        sh.selectunit([ship],function(q,k) {
-                            if (this.declareattack(self.index,q[k])){ 
-                                this.resolveattack(self.index,q[k]);
-                                activeunit=ship;
-                            }
-                            else ENGAGED=false;
-                        }.bind(sh),["Do Snap Shot attack? (Select self to cancel)"],true);
-                        self.phase = phase;
-                        ENGAGED=false;
+                        sh.donoaction([{org:self,type:"LASER",name:self.name,action:function(n){
+                            // Part of declareattack, possibly necessary for combatdial
+                            targetunit=ship;
+                            this.activeweapon=self.index;
+                            this.log("attacks %0 with %1",ship.name,this.weapons[self.index].name);
+                            ship.isattackedby(self.index,this);
+                            // Deep dive into resolveattack, removing EVERY SINGLE deferred usage!
+                            var i;
+                            //var r=this.gethitrange(w,targetunit);  // We know the range
+                            //this.addhasfired();  // We just remove this later, so why do it?
+                            this.hasdamaged=false;
+                            displaycombatdial();    // Let's see what this does...
+                            var bb=ship.g.getBBox();
+                            var start=transformPoint(this.m,{x:0,y:-(this.islarge?40:20)});
+                            s.path("M "+start.x+" "+start.y+" L "+(bb.x+bb.w/2)+" "+(bb.y+bb.h/2))
+                                .appendTo(VIEWPORT)
+                                .attr({stroke:this.color,
+                                       strokeWidth:2,
+                                       strokeDasharray:100,
+                                       "class":"animated fireline"});
+                            //this.select();        // Unnecessary
+                            for (i in squadron) if (squadron[i]==this) break;
+                            this.preattackroll(self.index,ship);
+                            var attack=this.getattackstrength(self.index,ship);
+                            //this.doattackroll(,,,i,n);
+
+                            //doattackroll: function(ar,ad,w,me=index of sh in squadron,n) {
+                            var ar=this.weapons[self.index].modifydamagegiven(this.attackroll(attack));
+                            this.weapons[self.index].lastattackroll=ar;
+                            displayattackroll(ar,attack);
+                            //this.log("target:"+targetunit.name+" "+defense+" "+ar+" "+ad+" "+defense+" "+n+" me:"+squadron[me].name);
+                            this.ar=ar;this.ad=attack;
+                            displayattacktokens(this,function(t) {
+                                    targetunit.predefenseroll(self.index,t);
+                                    targetunit.defenseroll(targetunit.getdefensestrength(self.index,t)).done(function(r){
+                                        //targetunit.dodefenseroll(r.roll,r.dice,me,n);
+                                        this.dr=r.roll; this.dd=r.dice;
+                                        displaydefenseroll(this.dr,this.dd);
+                                        displaydefensetokens(this,function() {
+                                            this.resolvedamage();
+                                            this.endnoaction(n,"LASER");
+                                            //this.endnoaction(n,"in combat");
+                                        }.bind(sh));
+                                }.bind(ship));
+                            });
+                            
+                            //ship.log("Bang Bang! %0 attack from %1 against %2", self.name, sh.name, ship.name);
+                            self.lastphase=self.phase;
+                            self.phase=phase;
+//                            this.endnoaction(n,"LASER");
+                                    //self.unit.selecttargetforattack(self.index,[ship]);
+                        }.bind(sh)}],"Snap Shot",true);
+                        if(phase != COMBAT_PHASE){
+                            sh.hasfired = 0;
+                        }
                     }
+                }
+            }
          });
-//	 Unit.prototype.wrap_before("endmaneuver",self,function() {
-//             // There are some restrictions on Snap Shot that should be checked prior
-//             // to adding any functionality to the holder (self.unit):
-//             // 1) activeunit is not self.unit                          check
-//             // 2) activeunit is not ally of self.unit                  check
-//             // 3) activeunit is within this weapon's range             check
-//             // 4) weapon has not fired this *phase*                    check
-//             // 5) weapon has not been activated for another target.    N/A
-//            if(this!=self.unit && (!this.isally(self.unit)) &&
-//                this.getrange(self.unit)<=self.unit.weapons[self.index].gethighrange())
-//            {
-//                if(self.phase < phase){
-//                   sh.doselection(function(n) {
-//                       self.unit.select();
-//                       self.unit.wrap_before("selecttargetforattack",self,function() {
-//                           self.unit.endnoaction(n,"ATTACK");
-//                       }).unwrapper("cleanupattack");
-//                       self.unit.wrap_after("getdicemodifiers",self,function() {
-//                           // Iterate back through arguments (all mods available to self.unit
-//                           // and remove any that Mod or Reroll the Attack Dice 
-//                            var i = arguments[0].length;
-//                            var newargs = arguments[0].slice();
-//                            var nextarg;
-//                            while (i--) {
-//                                nextarg = newargs[i];
-//                                if(nextarg.to == Unit.ATTACK_M || nextarg.from == Unit.ATTACK_M){
-//                                    if (newargs[i].type==Unit.MOD_M || newargs[i].type==Unit.REROLL_M) { 
-//                                        newargs.splice(i, 1);
-//                                    } 
-//                                }
-//                            }
-//                            return newargs;
-//                       }).unwrapper("cleanupattack");
-//                       self.unit.wrap_before("cancelattack",self,function() {
-//                           //self.unit.maxfired++;
-//                           self.phase = self.lastphase;
-//                           $("#attackdial").hide();
-//                           self.unit.endnoaction(n,"ATTACK");
-//                       }).unwrapper("cleanupattack");
-//                       // Check if this != this.isally(self.unit)?
-//                       // In this context, self.unit is Snap Shot host
-//                       // this is any ship
-//                        self.unit.doattack([self.unit.weapons[self.index]],[this]);
-//                   }.bind(this), this);
-//                }
-//            }
-//	 });
         }
     },
     {name:"M9-G8",

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -5483,11 +5483,14 @@ var UPGRADES=window.UPGRADES= [
                         $("#attackdial").empty();
                         ENGAGED=true;
                         sh.selectunit([ship],function(q,k) {
-                            if (this.declareattack(self.index,q[k])) 
+                            if (this.declareattack(self.index,q[k])){ 
                                 this.resolveattack(self.index,q[k]);
+                                activeunit=ship;
+                            }
                             else ENGAGED=false;
                         }.bind(sh),["Do Snap Shot attack? (Select self to cancel)"],true);
                         self.phase = phase;
+                        ENGAGED=false;
                     }
          });
 //	 Unit.prototype.wrap_before("endmaneuver",self,function() {

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -5478,30 +5478,16 @@ var UPGRADES=window.UPGRADES= [
                              }
                              return newargs;
                         }).unwrapper("cleanupattack");
-                        var number;
                         ship.log("Bang Bang! %0 attack from %1 against %2", self.name, sh.name, ship.name);
-                        sh.donoaction([{org:self,type:"LASER",name:self.name,action:function(n){
-                            number=n;
-                            if(sh.ia)
-                                this.doattack([self],[ship]);
-                            else
-                                this.resolveattack(self.index,ship);
-                                    //this.endnoaction(n,"LASER"); // This is the call that unlocks further execution!
-                        }.bind(sh)}],"",true).done([
-                            sh.endnoaction(number),
-                            ship.select()]
-                        );
-                        
-                        
                         //self.unit.selecttargetforattack(self.index,[ship]);
-//                        $("#attackdial").empty();
-//                        ENGAGED=true;
-//                        sh.selectunit([ship],function(q,k) {
-//                            if (this.declareattack(self.index,q[k])) 
-//                                this.resolveattack(self.index,q[k]);
-//                            else this.cleanupattack();
-//                        }.bind(sh),[""],false);
-//                        self.phase = phase;
+                        $("#attackdial").empty();
+                        ENGAGED=true;
+                        sh.selectunit([ship],function(q,k) {
+                            if (this.declareattack(self.index,q[k])) 
+                                this.resolveattack(self.index,q[k]);
+                            else ENGAGED=false;
+                        }.bind(sh),["Do Snap Shot attack? (Select self to cancel)"],true);
+                        self.phase = phase;
                     }
          });
 //	 Unit.prototype.wrap_before("endmaneuver",self,function() {

--- a/src/upgcards.js
+++ b/src/upgcards.js
@@ -5462,16 +5462,46 @@ var UPGRADES=window.UPGRADES= [
             if(!ship.isally(sh))
                 if(self.getenemiesinrange([ship]).length>0)
                     if(self.phase < phase){
+                        sh.wrap_after("getdicemodifiers",self,function() {
+                            // Iterate back through arguments (all mods available to self.unit
+                            // and remove any that Mod or Reroll the Attack Dice 
+                             var i = arguments[0].length;
+                             var newargs = arguments[0].slice();
+                             var nextarg;
+                             while (i--) {
+                                 nextarg = newargs[i];
+                                 if(nextarg.to == Unit.ATTACK_M || nextarg.from == Unit.ATTACK_M){
+                                     if (newargs[i].type==Unit.MOD_M || newargs[i].type==Unit.REROLL_M) { 
+                                         newargs.splice(i, 1);
+                                     } 
+                                 }
+                             }
+                             return newargs;
+                        }).unwrapper("cleanupattack");
+                        var number;
                         ship.log("Bang Bang! %0 attack from %1 against %2", self.name, sh.name, ship.name);
+                        sh.donoaction([{org:self,type:"LASER",name:self.name,action:function(n){
+                            number=n;
+                            if(sh.ia)
+                                this.doattack([self],[ship]);
+                            else
+                                this.resolveattack(self.index,ship);
+                                    //this.endnoaction(n,"LASER"); // This is the call that unlocks further execution!
+                        }.bind(sh)}],"",true).done([
+                            sh.endnoaction(number),
+                            ship.select()]
+                        );
+                        
+                        
                         //self.unit.selecttargetforattack(self.index,[ship]);
-                        $("#attackdial").empty();
-                        ENGAGED=true;
-                        sh.selectunit([ship],function(q,k) {
-                            if (this.declareattack(self.index,q[k])) 
-                                this.resolveattack(self.index,q[k]);
-                            else this.cleanupattack();
-                        }.bind(sh),[""],false);
-                        self.phase = phase;
+//                        $("#attackdial").empty();
+//                        ENGAGED=true;
+//                        sh.selectunit([ship],function(q,k) {
+//                            if (this.declareattack(self.index,q[k])) 
+//                                this.resolveattack(self.index,q[k]);
+//                            else this.cleanupattack();
+//                        }.bind(sh),[""],false);
+//                        self.phase = phase;
                     }
          });
 //	 Unit.prototype.wrap_before("endmaneuver",self,function() {


### PR DESCRIPTION
There were several issues with getting a bullet-proof, multi-activation Snap Shot implementation that worked: improper action locking, loss of execution chaining, overriding UI elements due to unlocked execution, and the fact that each instance of Snap Shot overrode the previous instance's invocation of wrap_after().  There was also an unprotected hole in Player-controlled action resolution that let execution revert back to the main Javascript loop, effectively halting the game until the player hits \<esc\>.

I used the $(document).on() event listener so that I could get rid of Unit.prototype.wrap_after, which I consider to be harmful (or at least very ugly).  I also added triggers to endmaneuver() so that each team gets notified at the end of any ship's maneuver.  That helped with the issue of Snap Shot instances overriding each other's wrap_after() - which made it impossible to use a Snap Shot on both teams at the same time.

By completely unwrapping the doattack() call stack I was able to remove every point where a new execution lock was introduced; this allowed me to track down the action resolution hole.  It also ensured that exactly one UI prompt was presented, greatly cleaning up the user experience.

The improper action locking and loss of execution chaining probably both stemmed from the action resolution hole - an execution path where the Player-controlled ship, after being fired on by an AI ship with Snap Shot, would fail to unlock its $deferred object - so I added an additional failsafe in endnoaction().  The engine uses actionrlock, a singleton jQuery deferred object, to detect when all queued actions have finished and signal that the current active unit has fully completed its turn.  Unfortunately, it is possible for an IAunit ship to signal that it (or even another ship) has completed its turn by calling actionrlock.resolve().  But if, due to execution order inversion (e.g. from Snap Shot), the Player ship is still finishing its action queue and has not defined its cleanup function, then calling actionrlock.resolve() appears to prevent the later-defined actionrlock.done(function(){...}) cleanup function from firing.  This ends the chain of execution and prevents the active ship from ending its turn.

The really strange thing is that IAUnits don't seem to have the same problem with ending the turn; even if they don't get an actionrlock.done() function defined, they complete their turns.  So currently every IAUnit passes through the new failsafe.  But this does not appear to cause any issues.

This approach should be useful for any effects that trigger after some defined phase of the game, or effects that only trigger on one team or the other.  Basically:

1) Add a " $(document).on(<phase name string>+<team number>, function(e,[<parameter 1>][...<parameter N>]){...}) " definition in the upgrade card, pilot, or weapon init function.  Given that we expect maybe one or two event triggers per second, I see no reason not to attach all of the listeners to the $(document) element at this point.

2) If necessary, add a set of $(document).trigger(<phase name string>+<team number[1,2]>, <array of additional parameters>) to one of the units.js or xwings.js functions that fires at the start or end of a phase, action, or maneuver.

3) In the .on(...) callback definition, use only the minimal number of low-level selection or donoaction/doaction calls necessary to achieve the desired effect.  Higher-level calls include tons of UI interrupts, nested action locks, and unpredictable side-functions involving display updates and end-of-activation closures that make debugging extraordinarily time-consuming, so I recommend using the barest low-level calls possible.